### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,15 @@
+- id: statix-fix
+  name: Statix Fix
+  description: Fix files with statix
+  entry: statix fix
+  types: [nix]
+  pass_filenames: false
+  language: system
+
+- id: statix-check
+  name: Statix Check
+  description: Check files for improvements with statix
+  entry: statix check
+  types: [nix]
+  pass_filenames: false
+  language: system


### PR DESCRIPTION
This adds two pre-commit hooks: 
- `statix-fix`, to automatically run `statix fix`
- `statix-check`, to automatically run `statix check`

Unfortunately, pre-commit can't automatically install statix due to pre-commit/pre-commit#2931, and it seems like the dev doesn't want to fix it.  
This still allows to use pre-commit hooks when statix has been installed manually. 