### PR TITLE
--deny warnings

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,8 @@
 
             buildFeatures = [ "json" ];
 
+            RUSTFLAGS = "--deny warnings";
+
             meta = with lib; {
               description = "Lints and suggestions for the Nix programming language";
               homepage = "https://git.peppe.rs/languages/statix/about";


### PR DESCRIPTION
This enforces no Rust warnings. There don't seem to be any at the moment. But I did artificially introduce one to test that this does indeed fail to build with it present.