### PR TITLE
Lint the linter via clippy + handle/fix findings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,8 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v18
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v30
       with:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
     - name: build statix

--- a/bin/src/config.rs
+++ b/bin/src/config.rs
@@ -213,18 +213,13 @@ pub struct Dump {}
 #[derive(Parser, Debug)]
 pub struct List {}
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 pub enum OutFormat {
     #[cfg(feature = "json")]
     Json,
     Errfmt,
+    #[default]
     StdErr,
-}
-
-impl Default for OutFormat {
-    fn default() -> Self {
-        OutFormat::StdErr
-    }
 }
 
 impl fmt::Display for OutFormat {

--- a/bin/src/traits.rs
+++ b/bin/src/traits.rs
@@ -80,7 +80,7 @@ fn write_stderr<T: Write>(
                 |cli_report, diagnostic| {
                     cli_report.with_label(
                         Label::new((src_id, range(diagnostic.at)))
-                            .with_message(&colorize(&diagnostic.message))
+                            .with_message(colorize(&diagnostic.message))
                             .with_color(Color::Magenta),
                     )
                 },

--- a/bin/src/utils.rs
+++ b/bin/src/utils.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use lib::{Lint, LINTS};
 use rnix::SyntaxKind;
 
+#[allow(clippy::borrowed_box)]
 pub fn lint_map_of(
     lints: &[&'static Box<dyn Lint>],
 ) -> HashMap<SyntaxKind, Vec<&'static Box<dyn Lint>>> {
@@ -19,6 +20,7 @@ pub fn lint_map_of(
     map
 }
 
+#[allow(clippy::borrowed_box)]
 pub fn lint_map() -> HashMap<SyntaxKind, Vec<&'static Box<dyn Lint>>> {
     lint_map_of(&LINTS)
 }

--- a/flake.nix
+++ b/flake.nix
@@ -34,8 +34,15 @@
           let
             pname = "statix";
             packageMeta = (lib.importTOML ./bin/Cargo.toml).package;
+            toolchain = (rustChannel final).withComponents [
+                "cargo"
+                "rustc"
+                "rust-std"
+                "clippy"
+            ];
             rustPlatform = makeRustPlatform {
-              inherit (rustChannel final) cargo rustc;
+                cargo = toolchain;
+                rustc = toolchain;
             };
           in
           rustPlatform.buildRustPackage {
@@ -54,6 +61,10 @@
               homepage = "https://git.peppe.rs/languages/statix/about";
               license = licenses.mit;
             };
+
+            checkPhase = ''
+              cargo clippy
+            '';
           };
 
         statix-vim =

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,9 @@
             nativeCheckInputs = [ clippy ];
 
             postCheck = ''
+              echo "Starting postCheck"
               cargo clippy
+              echo "Finished postCheck"
             '';
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -58,9 +58,8 @@
 
             nativeCheckInputs = [ clippy ];
 
-            checkPhase = ''
+            postCheck = ''
               cargo clippy
-              cargo test
             '';
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -34,16 +34,10 @@
           let
             pname = "statix";
             packageMeta = (lib.importTOML ./bin/Cargo.toml).package;
-            toolchain = (rustChannel final).withComponents [
-                "cargo"
-                "rustc"
-                "rust-std"
-                "clippy"
-            ];
             rustPlatform = makeRustPlatform {
-                cargo = toolchain;
-                rustc = toolchain;
+              inherit (rustChannel final) cargo rustc;
             };
+            clippy = (rustChannel final).clippy;
           in
           rustPlatform.buildRustPackage {
             inherit pname;
@@ -62,8 +56,11 @@
               license = licenses.mit;
             };
 
+            nativeCheckInputs = [ clippy ];
+
             checkPhase = ''
               cargo clippy
+              cargo test
             '';
           };
 

--- a/vfs/src/lib.rs
+++ b/vfs/src/lib.rs
@@ -48,6 +48,9 @@ impl ReadOnlyVfs {
     pub fn len(&self) -> usize {
         self.data.len()
     }
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
     pub fn file_path(&self, file_id: FileId) -> &Path {
         self.interner.lookup(file_id).unwrap()
     }


### PR DESCRIPTION
Integrates Clippy linting into the build process via `nix flake build`, ensuring automated code quality checks for all PRs.

This change includes:
- Fixed Clippy warnings by:
  - Using `#[derive(Default)]` for OutFormat enum
  - Correcting parameter references in Label creation
  - Adding `is_empty()` method to address Clippy recommendation
- Added `#[allow(clippy::borrowed_box)]` annotations for cases where fixing would require broader code changes (to be changed by further PRs)
- Updated GitHub Actions dependencies:
  - `actions/checkout` from v3 to v4
  - `cachix/install-nix-action` from v18 to v30 (resolves input parameter warnings). Older versions of cachix/install-nix-action didn't yet support the input parameter `github_access_token`.
- Modified flake.nix to include Clippy in the Rust toolchain and run it during the check phase

note: I am a first time contributor to the repo, so the workflow run is awaiting for approval. A green workflow run can be seen in my fork of the repo https://github.com/dbast/statix/actions/runs/13545008940