### PR TITLE
feat: detect useless parens in binops

### DIFF
--- a/bin/tests/data/useless_parens.nix
+++ b/bin/tests/data/useless_parens.nix
@@ -35,6 +35,11 @@ let
     4 * (5 / 5)
     ;
 
+  # primitive in binop
+  primitive_binop =
+    [1] ++ ([2])
+    ;
+
   # string concat
   s =
     (builtins.readFile ./x.txt)

--- a/bin/tests/data/useless_parens.nix
+++ b/bin/tests/data/useless_parens.nix
@@ -24,6 +24,17 @@ let
     * (2 + 2)
     ;
 
+  # precedence
+  prec1 =
+    4 + (5 * 3)
+    ;
+  prec2 =
+    (4 * 5) / 5
+    ;
+  prec3_no =
+    4 * (5 / 5)
+    ;
+
   # string concat
   s =
     (builtins.readFile ./x.txt)

--- a/bin/tests/data/useless_parens.nix
+++ b/bin/tests/data/useless_parens.nix
@@ -1,47 +1,41 @@
 let
   # parens around primitives
-  a = {
+  primitive = {
     b = ("hello");
     c = (d);
     e = ({ f = 2; });
   };
 
   # parens around let-value
-  g = (1 + 2);
-  h = ({ inherit i; });
+  value1 = (1 + 2);
+  value2 = ({ inherit i; });
 
-  # binary exprs with superflous parens
-  # TODO: we could implement associativity check to remove more redundant parens in the future
-  f =
+  binop =
     let id = x: x; in
     (id [3])
     ++ (id [1] ++ [2])
   ;
-
-  # binary exprs with necessary parens
-  u =
+  binop_no =
     (1 + 1)
     * (2 + 2)
     ;
 
   # precedence
-  prec1 =
+  arith1 =
     4 + (5 * 3)
     ;
-  prec2 =
+  arith2 =
     (4 * 5) / 5
     ;
-  prec3_no =
+  arith3_no =
     4 * (5 / 5)
     ;
 
-  # primitive in binop
   primitive_binop =
     [1] ++ ([2])
     ;
 
-  # string concat
-  s =
+  string_concat =
     (builtins.readFile ./x.txt)
     + (lib.optionalString true ''
       foo

--- a/bin/tests/data/useless_parens.nix
+++ b/bin/tests/data/useless_parens.nix
@@ -10,7 +10,32 @@ let
   g = (1 + 2);
   h = ({ inherit i; });
 
-  # TODO: binary exprs, function args etc.
+  # binary exprs with superflous parens
+  # TODO: we could implement associativity check to remove more redundant parens in the future
+  f =
+    let id = x: x; in
+    (id [3])
+    ++ (id [1] ++ [2])
+  ;
+
+  # binary exprs with necessary parens
+  u =
+    (1 + 1)
+    * (2 + 2)
+    ;
+
+  # string concat
+  s =
+    (builtins.readFile ./x.txt)
+    + (lib.optionalString true ''
+      foo
+    '')
+    + (lib.optionalString true ''
+      bar
+    '')
+    ;
+
+  # TODO: function args etc.
 in
   # parens around let body
   (null)

--- a/bin/tests/snapshots/main__useless_parens_fix.snap
+++ b/bin/tests/snapshots/main__useless_parens_fix.snap
@@ -5,7 +5,7 @@ expression: "& stdout"
 ---
 --- tests/data/useless_parens.nix
 +++ tests/data/useless_parens.nix [fixed]
-@@ -1,15 +1,15 @@
+@@ -1,21 +1,21 @@
  let
    # parens around primitives
    a = {
@@ -26,7 +26,31 @@ expression: "& stdout"
    # binary exprs with superflous parens
    # TODO: we could implement associativity check to remove more redundant parens in the future
    f =
-@@ -37,5 +37,5 @@
+     let id = x: x; in
+-    (id [3])
++    id [3]
+     ++ (id [1] ++ [2])
+   ;
+ 
+   # binary exprs with necessary parens
+@@ -25,17 +25,17 @@
+     ;
+ 
+   # string concat
+   s =
+-    (builtins.readFile ./x.txt)
+-    + (lib.optionalString true ''
++    builtins.readFile ./x.txt
++    + lib.optionalString true ''
+       foo
+-    '')
+-    + (lib.optionalString true ''
++    ''
++    + lib.optionalString true ''
+       bar
+-    '')
++    ''
+     ;
  
    # TODO: function args etc.
  in

--- a/bin/tests/snapshots/main__useless_parens_fix.snap
+++ b/bin/tests/snapshots/main__useless_parens_fix.snap
@@ -5,10 +5,10 @@ expression: "& stdout"
 ---
 --- tests/data/useless_parens.nix
 +++ tests/data/useless_parens.nix [fixed]
-@@ -1,22 +1,22 @@
+@@ -1,51 +1,51 @@
  let
    # parens around primitives
-   a = {
+   primitive = {
 -    b = ("hello");
 -    c = (d);
 -    e = ({ f = 2; });
@@ -18,47 +18,42 @@ expression: "& stdout"
    };
  
    # parens around let-value
--  g = (1 + 2);
--  h = ({ inherit i; });
-+  g = 1 + 2;
-+  h = { inherit i; };
+-  value1 = (1 + 2);
+-  value2 = ({ inherit i; });
++  value1 = 1 + 2;
++  value2 = { inherit i; };
  
-   # binary exprs with superflous parens
-   # TODO: we could implement associativity check to remove more redundant parens in the future
-   f =
+   binop =
      let id = x: x; in
 -    (id [3])
 -    ++ (id [1] ++ [2])
 +    id [3]
 +    ++ id [1] ++ [2]
    ;
- 
-   # binary exprs with necessary parens
-   u =
-@@ -25,33 +25,33 @@
+   binop_no =
+     (1 + 1)
+     * (2 + 2)
      ;
  
    # precedence
-   prec1 =
+   arith1 =
 -    4 + (5 * 3)
 +    4 + 5 * 3
      ;
-   prec2 =
+   arith2 =
 -    (4 * 5) / 5
 +    4 * 5 / 5
      ;
-   prec3_no =
+   arith3_no =
      4 * (5 / 5)
      ;
  
-   # primitive in binop
    primitive_binop =
 -    [1] ++ ([2])
 +    [1] ++ [2]
      ;
  
-   # string concat
-   s =
+   string_concat =
 -    (builtins.readFile ./x.txt)
 -    + (lib.optionalString true ''
 +    builtins.readFile ./x.txt

--- a/bin/tests/snapshots/main__useless_parens_fix.snap
+++ b/bin/tests/snapshots/main__useless_parens_fix.snap
@@ -35,7 +35,7 @@ expression: "& stdout"
  
    # binary exprs with necessary parens
    u =
-@@ -25,28 +25,28 @@
+@@ -25,33 +25,33 @@
      ;
  
    # precedence
@@ -49,6 +49,12 @@ expression: "& stdout"
      ;
    prec3_no =
      4 * (5 / 5)
+     ;
+ 
+   # primitive in binop
+   primitive_binop =
+-    [1] ++ ([2])
++    [1] ++ [2]
      ;
  
    # string concat

--- a/bin/tests/snapshots/main__useless_parens_fix.snap
+++ b/bin/tests/snapshots/main__useless_parens_fix.snap
@@ -5,7 +5,7 @@ expression: "& stdout"
 ---
 --- tests/data/useless_parens.nix
 +++ tests/data/useless_parens.nix [fixed]
-@@ -1,21 +1,21 @@
+@@ -1,22 +1,22 @@
  let
    # parens around primitives
    a = {
@@ -28,12 +28,27 @@ expression: "& stdout"
    f =
      let id = x: x; in
 -    (id [3])
+-    ++ (id [1] ++ [2])
 +    id [3]
-     ++ (id [1] ++ [2])
++    ++ id [1] ++ [2]
    ;
  
    # binary exprs with necessary parens
-@@ -25,17 +25,17 @@
+   u =
+@@ -25,28 +25,28 @@
+     ;
+ 
+   # precedence
+   prec1 =
+-    4 + (5 * 3)
++    4 + 5 * 3
+     ;
+   prec2 =
+-    (4 * 5) / 5
++    4 * 5 / 5
+     ;
+   prec3_no =
+     4 * (5 / 5)
      ;
  
    # string concat

--- a/bin/tests/snapshots/main__useless_parens_fix.snap
+++ b/bin/tests/snapshots/main__useless_parens_fix.snap
@@ -1,10 +1,11 @@
 ---
 source: bin/tests/main.rs
 expression: "& stdout"
+
 ---
 --- tests/data/useless_parens.nix
 +++ tests/data/useless_parens.nix [fixed]
-@@ -1,16 +1,16 @@
+@@ -1,15 +1,15 @@
  let
    # parens around primitives
    a = {
@@ -22,8 +23,15 @@ expression: "& stdout"
 +  g = 1 + 2;
 +  h = { inherit i; };
  
-   # TODO: binary exprs, function args etc.
+   # binary exprs with superflous parens
+   # TODO: we could implement associativity check to remove more redundant parens in the future
+   f =
+@@ -37,5 +37,5 @@
+ 
+   # TODO: function args etc.
  in
    # parens around let body
 -  (null)
 +  null
+
+

--- a/bin/tests/snapshots/main__useless_parens_lint.snap
+++ b/bin/tests/snapshots/main__useless_parens_lint.snap
@@ -4,9 +4,9 @@ expression: "& out"
 
 ---
 [W08] Warning: These parentheses can be omitted
-    ╭─[data/useless_parens.nix:41:3]
+    ╭─[data/useless_parens.nix:52:3]
     │
- 41 │   (null)
+ 52 │   (null)
     ·   ───┬──  
     ·      ╰──── Useless parentheses around body of let expression
 ────╯
@@ -51,23 +51,40 @@ expression: "& out"
  17 │     (id [3])
     ·     ────┬───  
     ·         ╰───── Useless parentheses in operand of binary operator
+ 18 │     ++ (id [1] ++ [2])
+    ·        ───────┬───────  
+    ·               ╰───────── Useless parentheses in operand of binary operator
 ────╯
 [W08] Warning: These parentheses can be omitted
-    ╭─[data/useless_parens.nix:33:7]
+    ╭─[data/useless_parens.nix:29:9]
     │
- 33 │ ╭─▶     + (lib.optionalString true ''
- 35 │ ├─▶     '')
+ 29 │     4 + (5 * 3)
+    ·         ───┬───  
+    ·            ╰───── Useless parentheses in operand of binary operator
+────╯
+[W08] Warning: These parentheses can be omitted
+    ╭─[data/useless_parens.nix:32:5]
+    │
+ 32 │     (4 * 5) / 5
+    ·     ───┬───  
+    ·        ╰───── Useless parentheses in operand of binary operator
+────╯
+[W08] Warning: These parentheses can be omitted
+    ╭─[data/useless_parens.nix:44:7]
+    │
+ 44 │ ╭─▶     + (lib.optionalString true ''
+ 46 │ ├─▶     '')
     · │             
     · ╰───────────── Useless parentheses in operand of binary operator
 ────╯
 [W08] Warning: These parentheses can be omitted
-    ╭─[data/useless_parens.nix:29:5]
+    ╭─[data/useless_parens.nix:40:5]
     │
- 29 │         (builtins.readFile ./x.txt)
+ 40 │         (builtins.readFile ./x.txt)
     ·         ─────────────┬─────────────  
     ·                      ╰─────────────── Useless parentheses in operand of binary operator
- 30 │ ╭─▶     + (lib.optionalString true ''
- 32 │ ├─▶     '')
+ 41 │ ╭─▶     + (lib.optionalString true ''
+ 43 │ ├─▶     '')
     · │             
     · ╰───────────── Useless parentheses in operand of binary operator
 ────╯

--- a/bin/tests/snapshots/main__useless_parens_lint.snap
+++ b/bin/tests/snapshots/main__useless_parens_lint.snap
@@ -4,9 +4,9 @@ expression: "& out"
 
 ---
 [W08] Warning: These parentheses can be omitted
-    ╭─[data/useless_parens.nix:57:3]
+    ╭─[data/useless_parens.nix:51:3]
     │
- 57 │   (null)
+ 51 │   (null)
     ·   ───┬──  
     ·      ╰──── Useless parentheses around body of let expression
 ────╯
@@ -32,66 +32,66 @@ expression: "& out"
    ·               ╰─────── Useless parentheses around value in binding
 ───╯
 [W08] Warning: These parentheses can be omitted
-    ╭─[data/useless_parens.nix:10:7]
+    ╭─[data/useless_parens.nix:10:12]
     │
- 10 │   g = (1 + 2);
-    ·       ───┬───  
-    ·          ╰───── Useless parentheses around value in binding
+ 10 │   value1 = (1 + 2);
+    ·            ───┬───  
+    ·               ╰───── Useless parentheses around value in binding
 ────╯
 [W08] Warning: These parentheses can be omitted
-    ╭─[data/useless_parens.nix:11:7]
+    ╭─[data/useless_parens.nix:11:12]
     │
- 11 │   h = ({ inherit i; });
-    ·       ────────┬───────  
-    ·               ╰───────── Useless parentheses around value in binding
+ 11 │   value2 = ({ inherit i; });
+    ·            ────────┬───────  
+    ·                    ╰───────── Useless parentheses around value in binding
 ────╯
 [W08] Warning: These parentheses can be omitted
-    ╭─[data/useless_parens.nix:17:5]
+    ╭─[data/useless_parens.nix:15:5]
     │
- 17 │     (id [3])
+ 15 │     (id [3])
     ·     ────┬───  
     ·         ╰───── Useless parentheses in operand of binary operator
- 18 │     ++ (id [1] ++ [2])
+ 16 │     ++ (id [1] ++ [2])
     ·        ───────┬───────  
     ·               ╰───────── Useless parentheses in operand of binary operator
 ────╯
 [W08] Warning: These parentheses can be omitted
-    ╭─[data/useless_parens.nix:29:9]
+    ╭─[data/useless_parens.nix:25:9]
     │
- 29 │     4 + (5 * 3)
+ 25 │     4 + (5 * 3)
     ·         ───┬───  
     ·            ╰───── Useless parentheses in operand of binary operator
 ────╯
 [W08] Warning: These parentheses can be omitted
-    ╭─[data/useless_parens.nix:32:5]
+    ╭─[data/useless_parens.nix:28:5]
     │
- 32 │     (4 * 5) / 5
+ 28 │     (4 * 5) / 5
     ·     ───┬───  
     ·        ╰───── Useless parentheses in operand of binary operator
 ────╯
 [W08] Warning: These parentheses can be omitted
-    ╭─[data/useless_parens.nix:40:12]
+    ╭─[data/useless_parens.nix:35:12]
     │
- 40 │     [1] ++ ([2])
+ 35 │     [1] ++ ([2])
     ·            ──┬──  
     ·              ╰──── Useless parentheses around primitive expression
 ────╯
 [W08] Warning: These parentheses can be omitted
-    ╭─[data/useless_parens.nix:49:7]
+    ╭─[data/useless_parens.nix:43:7]
     │
- 49 │ ╭─▶     + (lib.optionalString true ''
- 51 │ ├─▶     '')
+ 43 │ ╭─▶     + (lib.optionalString true ''
+ 45 │ ├─▶     '')
     · │             
     · ╰───────────── Useless parentheses in operand of binary operator
 ────╯
 [W08] Warning: These parentheses can be omitted
-    ╭─[data/useless_parens.nix:45:5]
+    ╭─[data/useless_parens.nix:39:5]
     │
- 45 │         (builtins.readFile ./x.txt)
+ 39 │         (builtins.readFile ./x.txt)
     ·         ─────────────┬─────────────  
     ·                      ╰─────────────── Useless parentheses in operand of binary operator
- 46 │ ╭─▶     + (lib.optionalString true ''
- 48 │ ├─▶     '')
+ 40 │ ╭─▶     + (lib.optionalString true ''
+ 42 │ ├─▶     '')
     · │             
     · ╰───────────── Useless parentheses in operand of binary operator
 ────╯

--- a/bin/tests/snapshots/main__useless_parens_lint.snap
+++ b/bin/tests/snapshots/main__useless_parens_lint.snap
@@ -1,11 +1,12 @@
 ---
 source: bin/tests/main.rs
 expression: "& out"
+
 ---
 [W08] Warning: These parentheses can be omitted
-    ╭─[data/useless_parens.nix:16:3]
+    ╭─[data/useless_parens.nix:41:3]
     │
- 16 │   (null)
+ 41 │   (null)
     ·   ───┬──  
     ·      ╰──── Useless parentheses around body of let expression
 ────╯
@@ -44,3 +45,4 @@ expression: "& out"
     ·       ────────┬───────  
     ·               ╰───────── Useless parentheses around value in binding
 ────╯
+

--- a/bin/tests/snapshots/main__useless_parens_lint.snap
+++ b/bin/tests/snapshots/main__useless_parens_lint.snap
@@ -4,9 +4,9 @@ expression: "& out"
 
 ---
 [W08] Warning: These parentheses can be omitted
-    ╭─[data/useless_parens.nix:52:3]
+    ╭─[data/useless_parens.nix:57:3]
     │
- 52 │   (null)
+ 57 │   (null)
     ·   ───┬──  
     ·      ╰──── Useless parentheses around body of let expression
 ────╯
@@ -70,21 +70,28 @@ expression: "& out"
     ·        ╰───── Useless parentheses in operand of binary operator
 ────╯
 [W08] Warning: These parentheses can be omitted
-    ╭─[data/useless_parens.nix:44:7]
+    ╭─[data/useless_parens.nix:40:12]
     │
- 44 │ ╭─▶     + (lib.optionalString true ''
- 46 │ ├─▶     '')
+ 40 │     [1] ++ ([2])
+    ·            ──┬──  
+    ·              ╰──── Useless parentheses around primitive expression
+────╯
+[W08] Warning: These parentheses can be omitted
+    ╭─[data/useless_parens.nix:49:7]
+    │
+ 49 │ ╭─▶     + (lib.optionalString true ''
+ 51 │ ├─▶     '')
     · │             
     · ╰───────────── Useless parentheses in operand of binary operator
 ────╯
 [W08] Warning: These parentheses can be omitted
-    ╭─[data/useless_parens.nix:40:5]
+    ╭─[data/useless_parens.nix:45:5]
     │
- 40 │         (builtins.readFile ./x.txt)
+ 45 │         (builtins.readFile ./x.txt)
     ·         ─────────────┬─────────────  
     ·                      ╰─────────────── Useless parentheses in operand of binary operator
- 41 │ ╭─▶     + (lib.optionalString true ''
- 43 │ ├─▶     '')
+ 46 │ ╭─▶     + (lib.optionalString true ''
+ 48 │ ├─▶     '')
     · │             
     · ╰───────────── Useless parentheses in operand of binary operator
 ────╯

--- a/bin/tests/snapshots/main__useless_parens_lint.snap
+++ b/bin/tests/snapshots/main__useless_parens_lint.snap
@@ -45,4 +45,30 @@ expression: "& out"
     ·       ────────┬───────  
     ·               ╰───────── Useless parentheses around value in binding
 ────╯
+[W08] Warning: These parentheses can be omitted
+    ╭─[data/useless_parens.nix:17:5]
+    │
+ 17 │     (id [3])
+    ·     ────┬───  
+    ·         ╰───── Useless parentheses in operand of binary operator
+────╯
+[W08] Warning: These parentheses can be omitted
+    ╭─[data/useless_parens.nix:33:7]
+    │
+ 33 │ ╭─▶     + (lib.optionalString true ''
+ 35 │ ├─▶     '')
+    · │             
+    · ╰───────────── Useless parentheses in operand of binary operator
+────╯
+[W08] Warning: These parentheses can be omitted
+    ╭─[data/useless_parens.nix:29:5]
+    │
+ 29 │         (builtins.readFile ./x.txt)
+    ·         ─────────────┬─────────────  
+    ·                      ╰─────────────── Useless parentheses in operand of binary operator
+ 30 │ ╭─▶     + (lib.optionalString true ''
+ 32 │ ├─▶     '')
+    · │             
+    · ╰───────────── Useless parentheses in operand of binary operator
+────╯
 

--- a/lib/src/lints/useless_parens.rs
+++ b/lib/src/lints/useless_parens.rs
@@ -114,56 +114,47 @@ fn do_thing(parsed_type_node: ParsedType) -> Option<OneOrMany<Diagnostic>> {
                 None
             }
         }
-        ParsedType::BinOp(bin_op) => {
+        ParsedType::BinOp(binop) => {
             let maybe_diagnostic = |(node, is_left): (SyntaxNode, bool)| -> Option<Diagnostic> {
                 let range = node.text_range();
                 let as_parens = Paren::cast(node)?;
                 let inner = as_parens.inner()?;
 
-                // TODO: unify this with binops
-                if Apply::cast(inner.clone()).is_some() {
-                    let at = range;
-                    let message = "Useless parentheses in operand of binary operator";
-                    let replacement = inner;
-                    Some(Diagnostic::suggest(
-                        at,
-                        message,
-                        Suggestion::new(at, replacement),
-                    ))
-                } else if let Some(nested) = BinOp::cast(inner.clone()) {
-                    // https://nix.dev/manual/nix/2.29/language/operators
-                    let prec_of = |op: BinOp| -> Option<(Prec, Assoc)> {
-                        Some(match op.operator()? {
-                            BinOpKind::IsSet => (4, Assoc::NoAssoc),
-                            BinOpKind::Concat => (5, Assoc::Right),
-                            BinOpKind::Mul | BinOpKind::Div => (6, Assoc::Left),
-                            BinOpKind::Add | BinOpKind::Sub => (7, Assoc::Left),
-                            BinOpKind::Update => (9, Assoc::Right),
-                            BinOpKind::Less
-                            | BinOpKind::LessOrEq
-                            | BinOpKind::More
-                            | BinOpKind::MoreOrEq => (10, Assoc::NoAssoc),
-                            BinOpKind::Equal | BinOpKind::NotEqual => (11, Assoc::NoAssoc),
-                            BinOpKind::And => (12, Assoc::Left),
-                            BinOpKind::Or => (13, Assoc::Left),
-                            BinOpKind::Implication => (14, Assoc::Right),
-                        })
-                    };
+                let suggestion = Diagnostic::suggest(
+                    range,
+                    "Useless parentheses in operand of binary operator",
+                    Suggestion::new(range, inner.clone()),
+                );
 
-                    let (outer_prec, outer_assoc) = prec_of(bin_op.clone())?;
-                    let (inner_prec, _inner_assoc) = prec_of(nested.clone())?;
+                // https://nix.dev/manual/nix/2.29/language/operators
+                let prec_of = |op: BinOp| -> Option<(Prec, Assoc)> {
+                    Some(match op.operator()? {
+                        BinOpKind::IsSet => (4, Assoc::NoAssoc),
+                        BinOpKind::Concat => (5, Assoc::Right),
+                        BinOpKind::Mul | BinOpKind::Div => (6, Assoc::Left),
+                        BinOpKind::Add | BinOpKind::Sub => (7, Assoc::Left),
+                        BinOpKind::Update => (9, Assoc::Right),
+                        BinOpKind::Less
+                        | BinOpKind::LessOrEq
+                        | BinOpKind::More
+                        | BinOpKind::MoreOrEq => (10, Assoc::NoAssoc),
+                        BinOpKind::Equal | BinOpKind::NotEqual => (11, Assoc::NoAssoc),
+                        BinOpKind::And => (12, Assoc::Left),
+                        BinOpKind::Or => (13, Assoc::Left),
+                        BinOpKind::Implication => (14, Assoc::Right),
+                    })
+                };
+
+                if Apply::cast(inner.clone()).is_some() {
+                    Some(suggestion)
+                } else if let Some(inner_binop) = BinOp::cast(inner.clone()) {
+                    let (outer_prec, outer_assoc) = prec_of(binop.clone())?;
+                    let (inner_prec, _) = prec_of(inner_binop.clone())?;
                     if inner_prec < outer_prec
                         || (inner_prec == outer_prec && (is_left && outer_assoc == Assoc::Left)
                             || (!is_left && outer_assoc == Assoc::Right))
                     {
-                        let at = range;
-                        let message = "Useless parentheses in operand of binary operator";
-                        let replacement = inner;
-                        Some(Diagnostic::suggest(
-                            at,
-                            message,
-                            Suggestion::new(at, replacement),
-                        ))
+                        Some(suggestion)
                     } else {
                         None
                     }
@@ -174,8 +165,8 @@ fn do_thing(parsed_type_node: ParsedType) -> Option<OneOrMany<Diagnostic>> {
 
             // Fix rhs then lhs otherwise the position will drift
             let diagnostics = vec![
-                bin_op.rhs().map(|node| (node, false)),
-                bin_op.lhs().map(|node| (node, true)),
+                binop.rhs().map(|node| (node, false)),
+                binop.lhs().map(|node| (node, true)),
             ]
             .into_iter()
             .flatten()

--- a/lib/src/lints/useless_parens.rs
+++ b/lib/src/lints/useless_parens.rs
@@ -135,10 +135,10 @@ fn do_thing(parsed_type_node: ParsedType) -> Option<OneOrMany<Diagnostic>> {
                 .filter_map(maybe_diagnostic)
                 .collect::<Vec<_>>();
 
-            if diagnostics.len() > 0 {
-                Some(OneOrMany::Many(diagnostics))
-            } else {
+            if diagnostics.is_empty() {
                 None
+            } else {
+                Some(OneOrMany::Many(diagnostics))
             }
         }
         ParsedType::Paren(paren_expr) => {

--- a/lib/src/lints/useless_parens.rs
+++ b/lib/src/lints/useless_parens.rs
@@ -190,8 +190,7 @@ fn do_thing(parsed_type_node: ParsedType) -> Option<OneOrMany<Diagnostic>> {
             // if this primitive is a let-body, we have already linted it
             && LetIn::cast(father_node.clone()).is_none()
 
-            // ensure that we don't lint inside of neither bin-op branches
-            && BinOp::cast(father_node).is_none()
+            // allow checking primitive expressions in binops
 
             && let Some(inner_node) = paren_expr.inner()
             && let Some(parsed_inner) = ParsedType::cast(inner_node)


### PR DESCRIPTION
Related to #14

Currently it only checks for functions in binops, other kinds of detection (e.g., associativity) are to be discussed.

Would it be reasonable to contribute to upstream and implement `Ord` or `PartialOrd` so that we could compare the precedence of different syntax nodes?

Related CPPNix documentation: https://nix.dev/manual/nix/2.29/language/operators