### PR TITLE
feat: add toml formatter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,3 @@
 [workspace]
 
-members = [
-    "bin",
-    "lib",
-    "macros",
-    "vfs",
-]
-
+members = ["bin", "lib", "macros", "vfs"]

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "statix"
-version = "0.5.8"
-edition = "2018"
-license = "MIT"
-authors = [ "Akshay <nerdy@peppe.rs>" ]
+authors     = ["Akshay <nerdy@peppe.rs>"]
 description = "Lints and suggestions for the Nix programming language"
+edition     = "2018"
+license     = "MIT"
+name        = "statix"
+version     = "0.5.8"
 
 [lib]
 name = "statix"
@@ -15,29 +15,29 @@ name = "statix"
 path = "src/main.rs"
 
 [dependencies]
-ariadne = "0.1.3"
-clap = "3.0.0-beta.4"
-ignore = "0.4.18"
-lib = { path = "../lib" }
-rayon = "1.5.1"
-rnix = "0.10.2"
-similar = "2.1.0"
+ariadne   = "0.1.3"
+clap      = "3.0.0-beta.4"
+ignore    = "0.4.18"
+lib       = { path = "../lib" }
+rayon     = "1.5.1"
+rnix      = "0.10.2"
+similar   = "2.1.0"
 thiserror = "1.0.30"
-toml = "0.5.8"
-vfs = { path = "../vfs" }
+toml      = "0.5.8"
+vfs       = { path = "../vfs" }
 
 [dependencies.serde]
-version = "1.0.68"
-features = [ "derive" ]
+features = ["derive"]
+version  = "1.0.68"
 
 [dependencies.serde_json]
-version = "1.0.68"
 optional = true
+version  = "1.0.68"
 
 [dev-dependencies]
-insta = "1.8.0"
+insta              = "1.8.0"
+paste              = "1.0.15"
 strip-ansi-escapes = "0.1.1"
-paste = "1.0.15"
 
 [features]
-json = [ "lib/json-out", "serde_json" ]
+json = ["lib/json-out", "serde_json"]

--- a/flake-parts/fmt.nix
+++ b/flake-parts/fmt.nix
@@ -14,11 +14,20 @@
             priority = 2;
           };
           prettier.enable = true;
-          # https://github.com/pappasam/toml-sort/issues/62
-          # toml-sort = {
-          #   enable = true;
-          #   all = true;
-          # };
+          taplo = {
+            enable = true;
+            priority = 1;
+            settings = {
+              formatting = {
+                align_entries = true; # Align entries vertically. Entries that have table headers, comments, or blank lines between them are not aligned.
+                reorder_keys = true; # Alphabetically reorder keys that are not separated by blank lines.
+                reorder_arrays = true; # Alphabetically reorder array values that are not separated by blank lines.
+                reorder_inline_tables = true; # Alphabetically reorder inline tables.
+                indent_tables = true; # Indent subtables if they come in order.
+                indent_entries = true; # Indent entries under tables.
+              };
+            };
+          };
           statix = {
             enable = true;
             priority = 1;

--- a/flake-parts/fmt.nix
+++ b/flake-parts/fmt.nix
@@ -23,8 +23,6 @@
                 reorder_keys = true; # Alphabetically reorder keys that are not separated by blank lines.
                 reorder_arrays = true; # Alphabetically reorder array values that are not separated by blank lines.
                 reorder_inline_tables = true; # Alphabetically reorder inline tables.
-                indent_tables = true; # Indent subtables if they come in order.
-                indent_entries = true; # Indent entries under tables.
               };
             };
           };

--- a/flake-parts/rust.nix
+++ b/flake-parts/rust.nix
@@ -19,8 +19,6 @@
         treefmt = {
           programs.rustfmt.enable = true;
           settings.global.excludes = [
-            "**/Cargo.toml"
-            "Cargo.toml"
             "bin/tests/snapshots/*.snap"
           ];
         };

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
-name = "lib"
-version = "0.0.0"
 edition = "2018"
 license = "MIT"
+name    = "lib"
+version = "0.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rnix = "0.10.2"
-if_chain = "1.0"
-macros = { path = "../macros" }
+if_chain    = "1.0"
 lazy_static = "1.0"
-rowan = "0.12.5"
-serde_json = { version = "1.0.68", optional = true }
+macros      = { path = "../macros" }
+rnix        = "0.10.2"
+rowan       = "0.12.5"
+serde_json  = { version = "1.0.68", optional = true }
 
 [dependencies.serde]
-version = "1.0.130"
-features = [ "derive" ]
+features = ["derive"]
 optional = true
+version  = "1.0.130"
 
 [features]
-default = []
-json-out = [ "serde", "serde_json" ]
+default  = []
+json-out = ["serde", "serde_json"]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name = "macros"
-version = "0.0.0"
 edition = "2018"
 license = "MIT"
+name    = "macros"
+version = "0.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-quote = "1.0"
 proc-macro2 = "1.0.27"
+quote       = "1.0"
 
 [dependencies.syn]
-version = "1.0"
-features = [ "full" ]
+features = ["full"]
+version  = "1.0"
 
 [lib]
 proc-macro = true

--- a/vfs/Cargo.toml
+++ b/vfs/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "vfs"
-version = "0.0.0"
 edition = "2018"
 license = "MIT"
+name    = "vfs"
+version = "0.0.0"
 
 [dependencies]
 indexmap = "1.6.2"
-rayon = "1.5.1"
+rayon    = "1.5.1"


### PR DESCRIPTION
`taplo` is way more stable and mature than `toml-sort`. This PR implements using it as part of the `nix fmt` routine.

I saw this while working on https://github.com/oppiliappan/statix/pull/102#issuecomment-3172469378 since formatting got in my way.