### PR TITLE
chore(msrv): stablize 'let' statements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = ["bin", "lib", "macros", "vfs"]
 [workspace.package]
 edition = "2024"
 license = "MIT"
+rust-version = "1.88.0"
 
 [workspace.dependencies]
 anyhow = "1.0.100"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Akshay <nerdy@peppe.rs>"]
 description = "Lints and suggestions for the Nix programming language"
 edition.workspace = true
 license.workspace = true
+rust-version.workspace = true
 name = "statix"
 version = "0.5.8"
 

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 name = "statix"
-version = "0.5.8"
+version = "0.5.9-pre"
 
 [lib]
 name = "statix"


### PR DESCRIPTION
edition 2024 existed in rust versions previous to 1.88, but
'let' chaining syntax had not yet settled down.

used <https://foresterre.github.io/cargo-msrv>

> This feature was stabilized in 1.88.0 but on edition 2024 only.

c.f. rust-lang/rust#53667
