### PR TITLE
fix(cli): prevent ariadne from panicking on empty stdin

### DIFF
--- a/bin/src/traits.rs
+++ b/bin/src/traits.rs
@@ -86,7 +86,10 @@ fn write_stderr<T: Write>(
                 },
             )
             .finish()
-            .write((src_id, Source::from(src)), &mut *writer)?;
+            .write(
+                (src_id, Source::from(if src.is_empty() { " " } else { src })),
+                &mut *writer,
+            )?;
     }
     Ok(())
 }


### PR DESCRIPTION
Fixes #78 

When statix receives an empty string via stdin, an empty Report is generated. Passing an empty string to ariadne's Source::from causes an index out of bounds panic. Supplying a string with a single space as a fallback prevents this panic while keeping the error location at byte offset 0.

Output after this fix-
```
 echo "" | nix run . -- check -s

[E00] Error: Syntax error
   ╭─[<stdin>:1:1]
   │
 1 │
   · │
   · ╰─ Unexpected end of file
───╯
```