### PR TITLE
Fix build and flake update

### DIFF
--- a/bin/src/fix.rs
+++ b/bin/src/fix.rs
@@ -73,7 +73,7 @@ pub mod main {
                     let src = fix_result
                         .map(|r| r.src)
                         .unwrap_or(Cow::Borrowed(entry.contents));
-                    println!("{}", &src);
+                    println!("{src}");
                 }
                 (FixOut::Write, Some(fix_result)) => {
                     let path = entry.file_path;
@@ -99,7 +99,7 @@ pub mod main {
                     .unwrap_or(Cow::Borrowed(original_src));
                 let text_diff = TextDiff::from_lines(original_src, &fixed_src);
                 let old_file = &path;
-                let new_file = format!("{} [fixed]", &path);
+                let new_file = format!("{path} [fixed]");
                 println!(
                     "{}",
                     text_diff
@@ -112,7 +112,7 @@ pub mod main {
                 let src = single_result
                     .map(|r| r.src)
                     .unwrap_or(Cow::Borrowed(original_src));
-                println!("{}", &src);
+                println!("{src}");
             }
             (FixOut::Write, Ok(single_result)) => {
                 let path = entry.file_path;

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754487366,
-        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755268003,
-        "narHash": "sha256-nNaeJjo861wFR0tjHDyCnHs1rbRtrMgxAKMoig9Sj/w=",
+        "lastModified": 1784872115,
+        "narHash": "sha256-THPEF2po0fsoH8gNtp+Ae0XFDJH3N/ol7xO3v6VMTJU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "32f313e49e42f715491e1ea7b306a87c16fe0388",
+        "rev": "335f0738cb2fa9708f3f428e39d2eae975d1338d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Fix build for new nixpkgs:

```
...
    Checking statix v0.5.8 (/build/source/bin)
error: redundant reference in `println!` argument
  --> bin/src/fix.rs:76:36
   |
76 |                     println!("{}", &src);
   |                                    ^^^^ help: remove the redundant `&`: `src`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_borrows_in_formatting
   = note: `-D clippy::useless-borrows-in-formatting` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::useless_borrows_in_formatting)]`

error: redundant reference in `format!` argument
   --> bin/src/fix.rs:102:54
    |
102 |                 let new_file = format!("{} [fixed]", &path);
    |                                                      ^^^^^ help: remove the redundant `&`: `path`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_borrows_in_formatting

error: redundant reference in `println!` argument
   --> bin/src/fix.rs:115:32
    |
115 |                 println!("{}", &src);
    |                                ^^^^ help: remove the redundant `&`: `src`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_borrows_in_formatting

error: could not compile `statix` (lib) due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
```